### PR TITLE
devops/fix-ci-timing-out

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,19 +13,18 @@ permissions:
 jobs:
   lint:
     runs-on: ubuntu-latest
-    timeout-minutes: 2
+    timeout-minutes: 5
     steps:
       - uses: actions/checkout@v4
       - uses: goto-bus-stop/setup-zig@v2
         with:
           version: 0.12.0
-
       - run: make lint 
 
 
   test:
     runs-on: ubuntu-latest
-    timeout-minutes: 2
+    timeout-minutes: 5
     steps:
       - uses: actions/checkout@v4
       - uses: goto-bus-stop/setup-zig@v2


### PR DESCRIPTION
This PR fixes an issue where the CI is timing out while setting up zig. New timeout is 5mins.