### PR TITLE
docs/fix-formatting-example-in-readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ const d = similarity(alloc, Metrics.Levenshtein, a, b);
 
 std.debug.print("similarity: {d:.0}%\n", .{d*100.0}); 
 // 
-// similarity: 0.57%
+// similarity: 57%
 //
 ```
 

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ const b = "sitting";
 
 const d = similarity(alloc, Metrics.Levenshtein, a, b);
 
-std.debug.print("similarity: {d:.0%}\n", .{d*100.0}); 
+std.debug.print("similarity: {d:.0}%\n", .{d*100.0}); 
 // 
 // similarity: 0.57%
 //

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ const b = "sitting";
 
 const d = similarity(alloc, Metrics.Levenshtein, a, b);
 
-std.debug.print("similarity: {d:.2%}\n", .{d}); 
+std.debug.print("similarity: {d:.0%}\n", .{d*100.0}); 
 // 
 // similarity: 0.57%
 //


### PR DESCRIPTION
This PR fixes a typo in the output code of one of the examples in the README.